### PR TITLE
fix: preserve enrollment when resealing fails

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1566,3 +1566,36 @@ test suite (`test/vm/run-vm-test.sh`) and Docker packaging tests
 (`test/distro/*`) don't invoke `install.sh` at all (they call
 `bin/seal.sh` / the PAM-dir-detection logic in `bin/lib.sh` directly), so
 they were unaffected by this change and required no update.
+
+## Failed re-seal now preserves the previous enrollment (2026-08-22)
+
+**Problem:** `bin/seal.sh` deleted `pcr.policy`, `seal.pub`, and
+`seal.priv` immediately after the user accepted the overwrite prompt. Every
+fallible operation needed to build the replacement happened afterward. A TPM
+error, interruption, or full filesystem during `tpm2_create` therefore turned
+a working enrollment into no enrollment at all. The two-entry password prompt
+only detects entries that differ from each other; it does not prove the
+resulting TPM object is loadable and unseals to the supplied bytes.
+
+**Fix:** build the PCR policy, public/private blobs, and handle metadata in a
+mode-0700 staging directory under `DATA_DIR`, leaving the installed files
+untouched. Load the staged object, open a fresh PCR policy session, unseal it,
+and compare the exact result to the supplied password. Only after that complete
+round trip succeeds are the staged files mode-normalized to 0600 and moved into
+place. Cleanup also flushes any TPM sessions/objects left live by a failed
+command before deleting the staging and context directories.
+
+Keeping staging below `DATA_DIR` is deliberate: it keeps staged files on the
+destination filesystem and avoids a cross-filesystem `mv` silently becoming a
+copy. This is failure-transactional for every checked command path; the four
+separate destination names are still not a single power-loss-atomic filesystem
+transaction, which would require a versioned state-directory format and an
+atomic pointer swap. That larger format migration was not necessary to fix the
+actual early-deletion bug and was deliberately kept out of this focused change.
+
+**Regression coverage:** the real-TPM VM test now shadows only `tpm2_create`
+with a helper that exits 42 during an accepted re-seal. It asserts that the
+re-seal fails and then invokes the real root helper against swtpm to prove the
+original secret still unseals. This would fail against the previous code
+because its early `rm -f` removed the old blobs before reaching the injected
+failure.

--- a/bin/seal.sh
+++ b/bin/seal.sh
@@ -31,7 +31,6 @@ chmod 700 "$DATA_DIR"
 if [ -f "$DATA_DIR/seal.priv" ]; then
   read -rp "A sealed secret already exists at $DATA_DIR. Overwrite? [y/N] " ans
   [[ "$ans" =~ ^[Yy]$ ]] || exit 0
-  rm -f "$DATA_DIR/pcr.policy" "$DATA_DIR/seal.pub" "$DATA_DIR/seal.priv"
 fi
 
 read -rsp "Password to seal (should match your GNOME login keyring password): " PASSWORD
@@ -46,7 +45,22 @@ if [ "$PASSWORD" != "$PASSWORD2" ]; then
 fi
 
 WORKDIR=$(mktemp -d)
-trap 'rm -rf "$WORKDIR"' EXIT
+# Keep the candidate enrollment on the same filesystem as DATA_DIR. The old
+# working files remain untouched until the new object has survived a complete
+# seal/load/unseal round trip.
+STAGE_DIR=$(mktemp -d "$DATA_DIR/.seal-stage.XXXXXX")
+chmod 700 "$STAGE_DIR"
+
+SESSION=""
+TEST_SESSION=""
+TEST_OBJECT=""
+cleanup() {
+  [ -z "$SESSION" ] || tpm2_flushcontext "$SESSION" >/dev/null 2>&1 || true
+  [ -z "$TEST_SESSION" ] || tpm2_flushcontext "$TEST_SESSION" >/dev/null 2>&1 || true
+  [ -z "$TEST_OBJECT" ] || tpm2_flushcontext "$TEST_OBJECT" >/dev/null 2>&1 || true
+  rm -rf -- "$WORKDIR" "$STAGE_DIR"
+}
+trap cleanup EXIT
 
 # The primary is persisted into the TPM's own NV storage at a fixed handle
 # instead of being recreated on every login. NOT the same thing as the
@@ -89,20 +103,53 @@ else
   echo "avoids recomputing it on every future login - see JOURNAL.md)."
   tpm2_evictcontrol -C o -c "$WORKDIR/primary.ctx" "$PRIMARY_HANDLE" >/dev/null
 fi
-echo "$PRIMARY_HANDLE" >"$DATA_DIR/primary.handle"
+printf '%s\n' "$PRIMARY_HANDLE" >"$STAGE_DIR/primary.handle"
 
 SESSION="$WORKDIR/session"
 tpm2_startauthsession -S "$SESSION" --policy-session >/dev/null
-tpm2_policypcr -S "$SESSION" -l "$PCR_BANK" -L "$DATA_DIR/pcr.policy" >/dev/null
+tpm2_policypcr -S "$SESSION" -l "$PCR_BANK" -L "$STAGE_DIR/pcr.policy" >/dev/null
 tpm2_flushcontext "$SESSION" >/dev/null
+SESSION=""
 
 printf '%s' "$PASSWORD" | tpm2_create -C "$PRIMARY_HANDLE" \
-  -u "$DATA_DIR/seal.pub" -r "$DATA_DIR/seal.priv" \
-  -L "$DATA_DIR/pcr.policy" -i- >/dev/null
+  -u "$STAGE_DIR/seal.pub" -r "$STAGE_DIR/seal.priv" \
+  -L "$STAGE_DIR/pcr.policy" -i- >/dev/null
+
+# Prove the complete candidate is usable before replacing a known-good
+# enrollment. This catches partial/corrupt tpm2_create output and policy or
+# TPM failures while rollback is still just deleting STAGE_DIR.
+TEST_OBJECT="$WORKDIR/test-seal.ctx"
+tpm2_load -C "$PRIMARY_HANDLE" \
+  -u "$STAGE_DIR/seal.pub" -r "$STAGE_DIR/seal.priv" \
+  -c "$TEST_OBJECT" >/dev/null
+
+TEST_SESSION="$WORKDIR/test-session"
+tpm2_startauthsession -S "$TEST_SESSION" --policy-session >/dev/null
+tpm2_policypcr -S "$TEST_SESSION" -l "$PCR_BANK" >/dev/null
+tpm2_unseal -c "$TEST_OBJECT" -p "session:$TEST_SESSION" \
+  >"$WORKDIR/unsealed"
+tpm2_flushcontext "$TEST_SESSION" >/dev/null
+TEST_SESSION=""
+tpm2_flushcontext "$TEST_OBJECT" >/dev/null
+TEST_OBJECT=""
+
+if ! printf '%s' "$PASSWORD" | cmp -s - "$WORKDIR/unsealed"; then
+  echo "TPM self-test returned a different secret; keeping the previous enrollment." >&2
+  exit 1
+fi
+
+chmod 600 "$STAGE_DIR/pcr.policy" "$STAGE_DIR/seal.pub" \
+  "$STAGE_DIR/seal.priv" "$STAGE_DIR/primary.handle"
 
 unset PASSWORD PASSWORD2
 
-echo "Sealed. Bound to this TPM and the current PCR7 (Secure Boot) state."
+# Each file is now complete, verified, and on the destination filesystem.
+# No earlier failure path modifies the previous enrollment.
+for name in pcr.policy seal.pub seal.priv primary.handle; do
+  mv -f "$STAGE_DIR/$name" "$DATA_DIR/$name"
+done
+
+echo "Sealed and self-tested. Bound to this TPM and the current PCR7 (Secure Boot) state."
 echo "Log out and back in to test the actual auto-unlock (via install.sh's"
 echo "PAM wiring), or check it directly with:"
 echo "  sudo /usr/local/sbin/tpm-keyring-unseal \$USER >/dev/null; echo \$?"

--- a/test/README.md
+++ b/test/README.md
@@ -79,6 +79,9 @@ script). Two scenarios:
   `tpm-keyring-unseal.sh` still unseals correctly. That's exactly the "integrity
   check failed" / "PCR have changed since checked" failure class documented
   in `JOURNAL.md`'s reboot-survival bugs, which no container can reproduce.
+  Before that reboot it also injects a deterministic `tpm2_create` failure
+  during re-sealing and proves that the previously working enrollment still
+  unseals, covering the transactional staging path in `bin/seal.sh`.
   It also fires two concurrent unseal calls at the real TPM to check the
   `flock` serialization fix for the second reboot regression in the journal.
 

--- a/test/vm/run-vm-test.sh
+++ b/test/vm/run-vm-test.sh
@@ -410,6 +410,26 @@ if wait_for_ssh "$B1_SSHPORT"; then
   echo "-- tpm-keyring-unseal.sh (same boot) took $(elapsed_ms "$UNSEAL1_START" "$UNSEAL1_END")ms --"
   check "tpm-keyring-unseal.sh returns the sealed secret (same boot)" "$GOT_SECRET" "$SECRET" "$WORK/unseal1.err"
 
+  # A failed re-seal must not destroy the enrollment that already proved it
+  # can unlock. Shadow only tpm2_create with a deterministic failure, accept
+  # the overwrite prompt, and confirm the original secret still unseals.
+  vm_ssh "$B1_SSHPORT" \
+    'mkdir -p ~/fail-bin && printf "#!/bin/sh\nexit 42\n" >~/fail-bin/tpm2_create && chmod 700 ~/fail-bin/tpm2_create'
+  if printf '%s\n%s\n%s\n' y replacement-secret replacement-secret | vm_ssh "$B1_SSHPORT" \
+       'PATH="$HOME/fail-bin:$PATH" bash ~/tpm-keyring-unlock/bin/seal.sh' \
+       >"$WORK/reseal-failure.out" 2>"$WORK/reseal-failure.err"; then
+    got=unexpected-success
+  else
+    got=failed-as-injected
+  fi
+  check "injected tpm2_create failure makes re-seal fail" "$got" "failed-as-injected" "$WORK/reseal-failure.err"
+
+  GOT_AFTER_FAILED_RESEAL="$(vm_ssh "$B1_SSHPORT" \
+    'sudo bash ~/tpm-keyring-unlock/pam/tpm-keyring-unseal.sh ubuntu' \
+    2>"$WORK/unseal-after-failed-reseal.err")"
+  check "failed re-seal preserves the previous working secret" \
+    "$GOT_AFTER_FAILED_RESEAL" "$SECRET" "$WORK/unseal-after-failed-reseal.err"
+
   # Two concurrent unseal calls against the same real TPM must both still
   # succeed - validates the flock serialization fix for the "PCR have
   # changed since checked" race (JOURNAL.md, second regression). Docker


### PR DESCRIPTION
## Summary

- keep the installed enrollment untouched while building a replacement
- stage the policy, sealed blobs, and handle metadata under `DATA_DIR`
- load and unseal the staged object, then compare the exact result before installing it
- clean up live TPM sessions/objects on failure
- add a real-swtpm regression that injects a failing `tpm2_create` and proves the old secret still unseals

Previously, accepting the overwrite prompt immediately deleted `pcr.policy`, `seal.pub`, and `seal.priv`. Any later TPM/tool/filesystem failure therefore destroyed a known-good enrollment. With this change, all fallible creation and self-test steps finish before the existing files are touched.

The final four file moves are not claimed to be one power-loss-atomic filesystem transaction; achieving that would require a versioned state format plus an atomic pointer swap. This PR stays focused on the observable early-deletion failure mode.

## Testing

- `bash -n bin/seal.sh test/vm/run-vm-test.sh install.sh uninstall.sh`
- `git diff --check`
- `make build` (clean `gcc -Wall -Wextra` build)
- `make test-regex`
- local fake-TPM round trip with a throwaway secret
- injected `tpm2_create` exit 42 during re-seal; all four installed file checksums remained unchanged and staging was cleaned up

The Docker daemon and `/dev/kvm` were unavailable locally, so the container and real-swtpm VM layers are left to CI. The VM regression added here exercises this exact failure against the existing swtpm setup.

## Related implementation

I also maintain an older, separate take on the same problem: [Tunahanyrd/tpm-keyring-unlock](https://github.com/Tunahanyrd/tpm-keyring-unlock). It uses a static Go user-session service and GNOME Keyring D-Bus instead of modifying PAM, with a single atomic state file, enrollment self-test, state ownership/symlink/permission checks, and bounded TPM/D-Bus calls. The architectures make different tradeoffs, but please feel free to steal any hardening ideas that are useful here. Conversely, this project's PAM integration and swtpm/QEMU coverage are excellent references for mine.
